### PR TITLE
add deploy-client rule to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ bin: $(BIN_PERL)
 
 deploy: build-libs deploy-libs deploy-docs deploy-scripts
 
+deploy-client: deploy
+
 build-libs:
 	-mkdir lib;
 	$(TPAGE) $(TPAGE_ARGS) Constants.pm.tt > Bio-KBase-Auth/lib/Bio/KBase/AuthConstants.pm


### PR DESCRIPTION
Added a deploy-client rule that simply runs the deploy rule.  This enables running 'make deploy-client' from a dev_container without errors. 
