### PR TITLE
Fixed Globus API call for fetching user information in Java auth library

### DIFF
--- a/java-libs/release_notes.txt
+++ b/java-libs/release_notes.txt
@@ -5,6 +5,17 @@ Java client for the KBase authorization service (and Globus Online directly
 where the KBase auth service doesn't yet have the required functionality).
 See the versions file for a mapping of git commit -> version.
 
+VERSION 0.3.1 (Released 5/15/15)
+------------------------------------------
+
+BUG FIXES
+- Fix for KBASE-2024 - looking up user info from Globus used a URL based on
+  the group path (i.e. /groups/[groupid]/members/[userid]), but not all kbase
+  users are in the kbase users group, thus WS sharing breaks for about 1/10th of
+  users which need to verify that the user account exists.  The URL was switched
+  to /users/[userid], which returns a user record regardless of group affiliation. 
+
+
 VERSION 0.3.0 (Released 4/8/15)
 ------------------------------------------
 

--- a/java-libs/src/us/kbase/auth/AuthConfig.java
+++ b/java-libs/src/us/kbase/auth/AuthConfig.java
@@ -25,7 +25,8 @@ public class AuthConfig {
 	
 	private static final String LOGIN_LOC = "Sessions/Login";
 	private static final String GLOBUS_GROUPS = "groups/";
-	private static final String GLOBUS_MEMBERS = "/members/";
+	private static final String GLOBUS_USERS = "users/";
+	private static final String GLOBUS_GROUP_MEMBERS = "/members/";
 			
 	private URI authServerURL;
 	private URI globusURL;
@@ -169,13 +170,30 @@ public class AuthConfig {
 	}
 	
 	/** Returns the full URL used for querying users with the Globus Online
-	 * service.
+	 * service within a specified group.
+	 * 
+	 * NOTE: not all valid KBase users are part of the KBase Globus Group! So
+	 * this URL should be used with extreme caution for looking up user information.
+	 *
 	 * @return the Globus user query URL.
 	 */
 	public URL getGlobusGroupMembersURL() {
 		try {
 			return globusURL.resolve(GLOBUS_GROUPS +
-					kbaseUsersGroupID.toString() + GLOBUS_MEMBERS).toURL();
+					kbaseUsersGroupID.toString() + GLOBUS_GROUP_MEMBERS).toURL();
+		} catch (MalformedURLException e) {
+			throw new RuntimeException("This should never happen");
+		}
+	}
+
+	/** Returns the full URL used for querying users with the Globus Online
+	 * service for any registered user regardles of group.
+
+	 * @return the Globus user query URL.
+	 */
+	public URL getGlobusUsersURL() {
+		try {
+			return globusURL.resolve(GLOBUS_USERS).toURL();
 		} catch (MalformedURLException e) {
 			throw new RuntimeException("This should never happen");
 		}

--- a/java-libs/src/us/kbase/auth/AuthService.java
+++ b/java-libs/src/us/kbase/auth/AuthService.java
@@ -241,11 +241,11 @@ public class AuthService {
 		for (final String name: result.keySet()) {
 			URL query = null;
 			try {
-				query = new URL(config.getGlobusGroupMembersURL().toString()
+				query = new URL(config.getGlobusUsersURL().toString()
 						+ name);
 			} catch (MalformedURLException mue) {
 				throw new RuntimeException("globus url " +
-						config.getGlobusGroupMembersURL() + 
+						config.getGlobusUsersURL() + 
 						" magically has illegal characters", mue);
 			}
 			final HttpsURLConnection conn = (HttpsURLConnection) query.openConnection();
@@ -283,7 +283,7 @@ public class AuthService {
 				USER_CACHE.putString(user);
 				result.put(user, new UserDetail(user,
 						(String) userdetail.get("email"),
-						(String) userdetail.get("name")));
+						(String) userdetail.get("fullname")));
 			}
 		}
 		return result;


### PR DESCRIPTION
This is a fix for critical bug https://atlassian.kbase.us/browse/KBASE-2024 , which prevented WS/Narrative sharing with a subset of KBase users.

Briefly, there was a recent change in the Globus API in fetching user information, which required a fix to the auth java library (see https://github.com/kbase/auth/pull/11).  However, this fix only allowed verification of users in the globus KBase group (so tests passed), but not all KBase users actually belong to this globus group so nothing could be shared with them.

This fix updates the globus API route used to be able to fetch a user profile regardless of group affiliations of that user.