### PR TITLE
Fix token issue date, sync refreshing token, more

### DIFF
--- a/java-libs/build.xml
+++ b/java-libs/build.xml
@@ -56,7 +56,7 @@
 
   <target name="test" depends="compile" description="run tests">
     <fail unless="test.user.password" message="property test.user.password not set."/>
-    <junit failureproperty="test.failed">
+    <junit failureproperty="test.failed" fork="yes">
       <classpath refid="compile.classpath"/>
       <classpath path="${compile.jarfile}"/>
       <classpath path="${test}"/>

--- a/java-libs/release_notes.txt
+++ b/java-libs/release_notes.txt
@@ -5,6 +5,14 @@ Java client for the KBase authorization service (and Globus Online directly
 where the KBase auth service doesn't yet have the required functionality).
 See the versions file for a mapping of git commit -> version.
 
+VERSION 0.3.2 (Released TBD)
+----------------------------
+
+BUG FIXES
+- Globus token lifetime changed back to previous value, so duplicated in
+  Authtoken class.
+- Made RefreshingToken.getToken() synchronized.
+
 VERSION 0.3.1 (Released 5/15/15)
 ------------------------------------------
 

--- a/java-libs/src/us/kbase/auth/AuthToken.java
+++ b/java-libs/src/us/kbase/auth/AuthToken.java
@@ -109,7 +109,7 @@ public class AuthToken {
 		final Calendar cal = Calendar.getInstance();
 		cal.setTime(exp);
 		cal.add(Calendar.YEAR, -1);
-		cal.add(Calendar.DAY_OF_YEAR, 1);
+//		cal.add(Calendar.DAY_OF_YEAR, 1);
 		issued = cal.getTime();
 		clientId = parsed.get("client_id");
 		tokenType = parsed.get("token_type");

--- a/java-libs/src/us/kbase/auth/RefreshingToken.java
+++ b/java-libs/src/us/kbase/auth/RefreshingToken.java
@@ -63,7 +63,8 @@ public class RefreshingToken {
 	 * @throws AuthException if the user credentials are no longer valid.
 	 * @throws IOException if an IO error occurs.
 	 */
-	public AuthToken getToken() throws AuthException, IOException {
+	public synchronized AuthToken getToken()
+			throws AuthException, IOException {
 		if (new Date().getTime() - refreshDate.getTime()
 				> refreshIntervalMSec) {
 			this.token = login(user, password);

--- a/java-libs/test/AuthServiceTest.java
+++ b/java-libs/test/AuthServiceTest.java
@@ -332,8 +332,9 @@ public class AuthServiceTest {
 		int clockSkew = (int)(token.getIssueDate().getTime() - new Date().getTime()) / 1000; // sec 
 
 		// If that clockSkew is < 0, flip the sign and add it to the short lifespan
-		if (clockSkew < 0)
+		if (clockSkew < 0) {
 			tokenLifespan -= clockSkew;
+		}
 
 		// Get a fresh token with a short expiry time.
 		token = AuthService.login(TEST_UID, TEST_PW, tokenLifespan).getToken();


### PR DESCRIPTION
Globus reversed their previous + 1d to token lifetime

Made the update token method in RefreshingToken synchronous

Fix ant junit tests as per
https://github.com/kbase/workspace_deluxe/commit/9ae8492d86efbcaf22423e40bdcc22cadd8af19f