### PR TITLE
Cache SHA-256 hash of token vs token, url init fix

### DIFF
--- a/java-libs/build.xml
+++ b/java-libs/build.xml
@@ -29,12 +29,12 @@
   <target name="compile" description="compile the source">
     <fail unless="compile.jarfile" message="property compile.jarfile not set."/>
     <!-- Compile class files-->
-    <javac srcdir="${src}" includeantruntime="false" target="1.6" source="1.6"
+    <javac srcdir="${src}" includeantruntime="false" target="1.7" source="1.7"
       debug="true" classpathref="compile.classpath"/>
     <!-- Make main jar file-->
     <jar destfile="${compile.jarfile}" basedir="${src}"/>
     <!-- Compile the tests -->
-    <javac srcdir="${test}" includeantruntime="false" target="1.6" source="1.6"
+    <javac srcdir="${test}" includeantruntime="false" target="1.7" source="1.7"
       debug="true">
       <classpath refid="compile.classpath"/>
       <classpath path="${compile.jarfile}"/>

--- a/java-libs/release_notes.txt
+++ b/java-libs/release_notes.txt
@@ -10,6 +10,8 @@ VERSION 0.4.1 (Released 7/31/16)
 
 BUG FIXES
 - Fixed a bug that allowed configuration of incorrect urls.
+- Token cache now stores a SHA-256 digest of the token rather than the token
+  itself.
 
 VERSION 0.4.0 (Released 7/31/16)
 --------------------------------

--- a/java-libs/release_notes.txt
+++ b/java-libs/release_notes.txt
@@ -5,8 +5,14 @@ Java client for the KBase authorization service (and Globus Online directly
 where the KBase auth service doesn't yet have the required functionality).
 See the versions file for a mapping of git commit -> version.
 
+VERSION 0.4.1 (Released 7/31/16)
+--------------------------------
+
+BUG FIXES
+- Fixed a bug that allowed configuration of incorrect urls.
+
 VERSION 0.4.0 (Released 7/31/16)
----------------------------
+--------------------------------
 
 BACKWARDS INCOMPATIBILITIES:
 - All RefreshingToken methods and classes are deprecated. They will fail once

--- a/java-libs/src/us/kbase/auth/AuthService.java
+++ b/java-libs/src/us/kbase/auth/AuthService.java
@@ -46,6 +46,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class AuthService {
 	
+	/* should really handle tokens and pwds as char[] instead of String so the
+	 * char[] can be wiped when it's no longer needed. But since they're going
+	 * over the wire they're probably already strings or will be converted to
+	 * Strings at some point or another.
+	 */
+	
 	private AuthService() {};
 	
 	private final static AuthConfig DEFAULT_CONFIG = new AuthConfig();
@@ -393,19 +399,23 @@ public class AuthService {
 	}
 	
 	static AuthToken validateToken(
-			final String tokenStr,
+			final String token,
 			final AuthConfig config)
 			throws IOException, AuthException {
+		if (token == null || token.isEmpty()) {
+			throw new IllegalArgumentException("token cannot be null or empty");
+		}
+		//TODO NOW throw npe if token is null
 		
 		// If it's in the cache, then it's valid.
-		final AuthToken t = TOKEN_CACHE.getToken(tokenStr);
+		final AuthToken t = TOKEN_CACHE.getToken(token);
 		if (t != null) {
 			return t;
 		}
 
 		// Otherwise, fetch the user from the Auth Service.
 		// if we get a user back (and not an exception), then the token is valid.
-		final String dataStr = "token=" + tokenStr + "&fields=user_id,token";
+		final String dataStr = "token=" + token + "&fields=user_id,token";
 		final AuthUser u = fetchUser(dataStr, config);
 		TOKEN_CACHE.putValidToken(u.getToken());
 		return u.getToken();
@@ -463,7 +473,8 @@ public class AuthService {
 	 */
 	static void checkServiceUrl(URL url) throws IOException {
 
-		//TODO LATER need to support HTTP connections for testing purposes, but need to make it very explicit that's happening (like the SDK java clients)
+		//TODO AUTH2 need to support HTTP connections for testing purposes, but need to make it very explicit that's happening (like the SDK java clients)
+		
 		HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
 
 		int response = conn.getResponseCode();
@@ -483,6 +494,6 @@ public class AuthService {
 			if (!result.contains("\"user_id\": null")) {
 				throw new IOException("Auth service URL invalid");
 			}
-		}
+		} //TODO NOW uh... should be throwing an error here
 	}
 }

--- a/java-libs/src/us/kbase/auth/ConfigurableAuthService.java
+++ b/java-libs/src/us/kbase/auth/ConfigurableAuthService.java
@@ -13,13 +13,6 @@ import java.util.Map;
  * cache is static across all instances of ConfigurableAuthService and the
  * static AuthService class.
  * 
- * AuthUser user = new AuthService().login(user, password);
- * if (new AuthService().validateToken(user.getToken())) {
- * 		// There's a valid token! Return the valid user, or just the token, and move along.
- * }
- * 
- * Thus, this provides code for a user to log in to KBase, retrieve a valid
- * Auth token, and optionally validate it.
  * 
  * All tokens seen by this class are cached by the
  * {@link us.kbase.auth.TokenCache} class.
@@ -32,6 +25,9 @@ public class ConfigurableAuthService {
 	private final AuthConfig config;
 
 	/** Create an authorization service client with the default configuration.
+	 * Checks that the url provided in the config is valid by calling the auth
+	 * service. As such, do not repeatedly instantiate a client - instantiate
+	 * it once and save it.
 	 * @throws IOException if an IO error occurs.
 	 */
 	public ConfigurableAuthService() throws IOException {

--- a/java-libs/src/us/kbase/auth/TokenCache.java
+++ b/java-libs/src/us/kbase/auth/TokenCache.java
@@ -22,6 +22,14 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class TokenCache {
 	
+	/* should really handle tokens as char[] instead of String so the
+	 * char[] can be wiped when it's no longer needed. But since they're going
+	 * over the wire they're probably already strings or will be converted to
+	 * Strings at some point or another.
+	 */
+	
+	//TODO NOW digest the token before putting it in a map
+	
 	/**
 	 * Default nominal size of the cache.
 	 */
@@ -76,6 +84,10 @@ public class TokenCache {
 	 * @return an AuthToken.
 	 */
 	public AuthToken getToken(final String token) {
+		if (token == null || token.isEmpty()) {
+			throw new IllegalArgumentException(
+					"token cannot be null or empty");
+		}
 		final UserDate ud = cache.get(token);
 		if (ud == null) {
 			return null;
@@ -91,6 +103,9 @@ public class TokenCache {
 	 * @param token the token to add
 	 */
 	public void putValidToken(AuthToken token) {
+		if (token == null) {
+			throw new NullPointerException("token cannot be null");
+		}
 		cache.put(token.getToken(), new UserDate(token.getUserName()));
 		synchronized (cache) { // block here otherwise all threads may start sorting
 			if (cache.size() <= maxsize) {

--- a/java-libs/src/us/kbase/auth/TokenCache.java
+++ b/java-libs/src/us/kbase/auth/TokenCache.java
@@ -31,8 +31,6 @@ public class TokenCache {
 	 * Strings at some point or another.
 	 */
 	
-	//TODO NOW digest the token before putting it in a map
-	
 	/**
 	 * Default nominal size of the cache.
 	 */

--- a/java-libs/test/AuthServiceTest.java
+++ b/java-libs/test/AuthServiceTest.java
@@ -128,6 +128,25 @@ public class AuthServiceTest {
 		System.out.println("Done testing!");
 	}
 	
+	@Test
+	public void badAuthUrl() throws Exception {
+		failSetUrl("https://kbase.us/authorizations",
+				"Auth service URL https://kbase.us/authorizations/Sessions/Login is invalid. Server said: 404 Not Found");
+		failSetUrl("https://foobarbazbangfakefakefake.com/authorization",
+				"foobarbazbangfakefakefake.com"); // unknown host
+	}
+	
+	private void failSetUrl(final String url, final String exp)
+			throws Exception {
+		final URL u = new URL(url);
+		final AuthConfig ac = new AuthConfig().withKBaseAuthServerURL(u);
+		try {
+			new ConfigurableAuthService(ac);
+		} catch (IOException ioe) {
+			assertThat("incorrect exception", ioe.getMessage(), is(exp));
+		}
+	}
+
 	//test tokencache
 	@Test
 	public void authTokenConstruction() throws Exception {

--- a/java-libs/test/AuthServiceTest.java
+++ b/java-libs/test/AuthServiceTest.java
@@ -186,6 +186,33 @@ public class AuthServiceTest {
 	}
 	
 	@Test
+	public void tokenCachePutValidTokenBadArgs() throws Exception {
+		final TokenCache tc = new TokenCache();
+		try {
+			tc.putValidToken(null);
+		} catch (NullPointerException npe) {
+			assertThat("incorrect exception", npe.getMessage(),
+					is("token cannot be null"));
+		}
+	}
+	
+	@Test
+	public void tokenCacheGetTokenBadArgs() throws Exception {
+		failGetToken("");
+		failGetToken(null);
+	}
+	
+	private void failGetToken(final String token) {
+		final TokenCache tc = new TokenCache();
+		try {
+			tc.getToken(token);
+		} catch (IllegalArgumentException iae) {
+			assertThat("incorrect exception", iae.getMessage(),
+					is("token cannot be null or empty"));
+		}
+	}
+
+	@Test
 	public void tokenCacheDropsExpiredTokens() throws Exception {
 		TokenCache tc = new TokenCache(2, 3);
 		Field f = tc.getClass().getDeclaredField("MAX_AGE_MS");
@@ -586,6 +613,28 @@ public class AuthServiceTest {
 		AuthService.validateToken("asdf");
 	}
 	
+	@Test
+	public void validateTokenBadArgs() throws Exception {
+		failValidate("");
+		failValidate(null);
+	}
+	
+	private void failValidate(String token) throws Exception {
+		try {
+			AuthService.validateToken(token);
+		} catch (IllegalArgumentException iae) {
+			assertThat("incorrect exception", iae.getMessage(),
+					is("token cannot be null or empty"));
+		}
+		final ConfigurableAuthService cas = new ConfigurableAuthService();
+		try {
+			cas.validateToken(token);
+		} catch (IllegalArgumentException iae) {
+			assertThat("incorrect exception", iae.getMessage(),
+					is("token cannot be null or empty"));
+		}
+	}
+
 	@Test(expected = AuthException.class)
 	public void testFailValidateConfigurable() throws AuthException, IOException {
 		new ConfigurableAuthService().validateToken("asdf");


### PR DESCRIPTION
* Cache now stores a SHA-256 hash of the token rather than the bare token
* Fixed a bug that would allow initializing the client with a bad kbase url