### PR TITLE
Handle incoming URLs with Sessions/Login already set

### DIFF
--- a/java-libs/release_notes.txt
+++ b/java-libs/release_notes.txt
@@ -5,6 +5,16 @@ Java client for the KBase authorization service (and Globus Online directly
 where the KBase auth service doesn't yet have the required functionality).
 See the versions file for a mapping of git commit -> version.
 
+VERSION 0.4.3 (Released 9/16/16)
+--------------------------------
+
+UPDATED FEATURES / BUG FIXES:
+- If the URL provided for the KBase auth service ends with Sessions/Login or
+  Sessions/Login/ that suffix will be removed from the url.
+  AuthConfig.getAuthServerURL() will return this modified URL, while
+  AuthConfig.getAuthLoginURL() will, as usual, return the URL returned by
+  getAuthServerURL() appended with /Sessions/Login.
+
 VERSION 0.4.2 (Released 8/25/16)
 --------------------------------
 

--- a/java-libs/src/us/kbase/auth/AuthConfig.java
+++ b/java-libs/src/us/kbase/auth/AuthConfig.java
@@ -73,7 +73,10 @@ public class AuthConfig {
 		kbaseUsersGroupID = UUID.fromString(DEFAULT_KBASE_USER_GROUP_ID);
 	}
 	
-	/** Set the URL of the KBase authorization server
+	/** Set the URL of the KBase authorization server. Note that to maintain
+	 * compatibility with other languages' auth clients and previous versions
+	 * of this client, URLs ending in Sessions/Login or Sessions/Login/ will
+	 * have that portion of the URL removed.
 	 * @param authServer the URL of the KBase authorization server.
 	 * @return this
 	 * @throws URISyntaxException if the URL is not a valid URI. In general
@@ -88,7 +91,18 @@ public class AuthConfig {
 			try {
 				authServer = new URL(authServer.toString() + "/");
 			} catch (MalformedURLException e) {
-				throw new RuntimeException("This can't happen");
+				throw new RuntimeException("This can't happen", e);
+			}
+		}
+		if (authServer.getPath().endsWith(LOGIN_LOC) ||
+				authServer.getPath().endsWith(LOGIN_LOC + "/")) {
+			final int index = authServer.toString().lastIndexOf(LOGIN_LOC);
+			try {
+				authServer = new URL(authServer.toString()
+						.substring(0, index));
+			} catch (MalformedURLException e) {
+				throw new RuntimeException(
+						"The impossible just occured. Congratulations.", e);
 			}
 		}
 		authServerURL = authServer.toURI();

--- a/java-libs/test/AuthServiceTest.java
+++ b/java-libs/test/AuthServiceTest.java
@@ -493,6 +493,27 @@ public class AuthServiceTest {
 	}
 	
 	@Test
+	public void configURLTruncation() throws Exception {
+		/* Test that magic urls are truncated correctly */
+		final URL kbase = new URL(
+				"https://www.kbase.us/services/authorization/");
+		final URL kbasess = new URL(kbase.toString() + "Sessions/Login");
+		final URL kbasess2 = new URL(kbase.toString() + "Sessions/Login/");
+		final URL kbasess3 = new URL(kbase.toString() + "Sessions/Login/a");
+		assertThat("incorrect truncated url", new AuthConfig()
+				.withKBaseAuthServerURL(kbase).getAuthServerURL(), is(kbase));
+		assertThat("incorrect truncated url", new AuthConfig()
+				.withKBaseAuthServerURL(kbasess).getAuthServerURL(),
+				is(kbase));
+		assertThat("incorrect truncated url", new AuthConfig()
+				.withKBaseAuthServerURL(kbasess2).getAuthServerURL(),
+				is(kbase));
+		assertThat("incorrect truncated url", new AuthConfig()
+				.withKBaseAuthServerURL(kbasess3)
+				.getAuthServerURL(), is(new URL(kbasess3.toString() + "/")));
+	}
+	
+	@Test
 	public void configObject() throws Exception {
 		
 		assertThat("incorrect default auth url",


### PR DESCRIPTION
For compatibility with the Perl and Python servers and backwards
compatibility with prior versions of the Java client, Sessions/Login or
Sessions/Login/ will now be removed from the end of service urls
supplied to an AuthConfig.